### PR TITLE
Fix JSON's gs:// addresses

### DIFF
--- a/variant-caller-wdl/topmed_freeze8_caller_small_gs.json
+++ b/variant-caller-wdl/topmed_freeze8_caller_small_gs.json
@@ -1,8 +1,8 @@
 {
   "TopMedVariantCaller.input_cram_files": [
-  "gs://topmed_workflow_testing/topmed_variant_caller/input_files/NWD176325.chr1_10000000-11000000.recab.cram",
-  "gs://topmed_workflow_testing/topmed_variant_caller/input_files/NWD119836.chr1_10000000-11000000.recab.cram",
-  "gs://topmed_workflow_testing/topmed_variant_caller/input_files/NWD119844.chr1_10000000-11000000.recab.cram"
+  "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD176325.chr1_10000000-11000000.recab.cram",
+  "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD119836.chr1_10000000-11000000.recab.cram",
+  "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD119844.chr1_10000000-11000000.recab.cram"
   ],
   "TopMedVariantCaller.referenceFilesBlob": "gs://topmed_workflow_testing/topmed_variant_caller/reference_files/topmed_variant_calling_example_resources.tar.gz"
 }


### PR DESCRIPTION
These files do not exist in the variant caller directory, but they do exist in the aligner directory. This would fix the currently invalid JSON on Dockstore.